### PR TITLE
chore: add game-version migration skill, CLAUDE.md

### DIFF
--- a/.claude/skills/migrate-game-version/SKILL.md
+++ b/.claude/skills/migrate-game-version/SKILL.md
@@ -44,11 +44,11 @@ Run the helper from the repo root. Dry-run first to eyeball the output, then app
 
 ```powershell
 # stage only — nothing tracked changes
-pwsh .claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1
 
 # write into the repo: Patched skeletons -> System/Patched,
 # verbatim decomps -> System/Experimental as diff references
-pwsh .claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1 -Apply -WriteUnpatched
+powershell -NoProfile -ExecutionPolicy Bypass -File .claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1 -Apply -WriteUnpatched
 ```
 
 This decompiles both systems at `-lv CSharp7_3`, then applies the stable header

--- a/.claude/skills/migrate-game-version/SKILL.md
+++ b/.claude/skills/migrate-game-version/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: migrate-game-version
+description: >-
+  Migrate the All Aboard! mod's decompiled transport AI systems
+  (PatchedTransportCarAISystem / PatchedTransportTrainAISystem) to a new Cities:
+  Skylines II game version. Use this whenever the user mentions a new CS2 version
+  or game patch (e.g. "1.5.9f1", "CO shipped an update", "the game updated",
+  "new Paradox build"), wants to re-decompile / rebase / migrate the patched
+  systems, is working on an `integration/<version>` branch, or the mod stopped
+  compiling after a game update. It decompiles Game.dll with ilspycmd, rewrites
+  the namespace/class, splices the configurable dwell-cap hook into StopBoarding,
+  build-verifies, and bumps the version + changelog. Prefer this skill over doing
+  the decompile-and-patch by hand.
+---
+
+# Migrate All Aboard! to a new game version
+
+When Colossal Order ships a CS2 patch, the mod's two `Patched*AISystem` files —
+verbatim decompiles of the stock `TransportCarAISystem` / `TransportTrainAISystem`
+with one hook spliced into each — must be re-rebased onto the new game code. The
+mod replaces those systems wholesale (Burst compilation rules out a lighter Harmony
+patch), so a fresh decompile is unavoidable on each update.
+
+This skill splits the job into the part that's mechanical and stable (scripted) and
+the part that needs judgement every time because CO reshapes the code (you do it,
+guided by `references/hook-splices.md`). The compile is the correctness gate.
+
+## Prerequisites
+
+- **ilspycmd** on PATH (`dotnet tool install -g ilspycmd`). This is the
+  ICSharpCode.Decompiler CLI — the same engine Rider bundles. The mod's older files
+  carry a dotPeek header, but dotPeek-the-standalone isn't required; ilspycmd output
+  at `-lv CSharp7_3` is block-scoped and net48-compatible, which is what matters.
+- The game installed and **updated to the target version** — the script reads the
+  live `Game.dll` via the `CSII_INSTALLATIONPATH` / `CSII_MANAGEDPATH` env vars the
+  modding toolchain sets. Confirm `Game.dll`'s timestamp matches the new patch.
+- `CSII_TOOLPATH` set (the build imports `Mod.props`/`Mod.targets` from it).
+
+## Workflow
+
+### 1. Decompile + rewrite (scripted)
+
+Run the helper from the repo root. Dry-run first to eyeball the output, then apply:
+
+```powershell
+# stage only — nothing tracked changes
+pwsh .claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1
+
+# write into the repo: Patched skeletons -> System/Patched,
+# verbatim decomps -> System/Experimental as diff references
+pwsh .claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1 -Apply -WriteUnpatched
+```
+
+This decompiles both systems at `-lv CSharp7_3`, then applies the stable header
+rewrite: `namespace Game.Simulation` → `AllAboard.System.Patched`, class +
+constructor rename to `Patched*`, and injects `using AllAboard.System.Utility;`. The
+resulting `Patched*.cs` are still pure vanilla logic — **the hook is not yet spliced.**
+
+The `Unpatched*.cs` copies in `System/Experimental/` are the diff anchors: they let
+you see exactly what CO changed this version, and (after you splice) they make the
+hook diff trivially reviewable.
+
+**Commit this as the "decomp migration"** before splicing — matching the repo's
+convention (`chore: migrate decomp to <version>`). That keeps the next commit (the
+splice) showing only the hook, which is what a reviewer cares about.
+
+### 2. Splice the hook (judgement)
+
+Read `references/hook-splices.md` and apply the hook to each `Patched*.cs`. There's
+one hook per file, inside `StopBoarding`. In short: excise vanilla's hardcoded
+1800-frame dwell cap and route the passenger-readiness decision through
+`PublicTransportBoardingHelper.ArePassengersReady(...)` so the user's slider is the
+sole authority.
+
+Do **not** pattern-match last version's exact text — CO renames locals (`flag2` vs
+`flag3`) and refactors freely (1.5.9 moved the train's per-vehicle check into its own
+method). Find the hook by its role (the loop/method touching `CreatureVehicleFlags.Ready`
+inside `if (!forcedStop)`), preserve everything else the new decomp added, and apply
+the documented transform.
+
+### 3. Build-verify (the gate)
+
+```powershell
+dotnet build AllAboard.sln -c Release
+```
+
+A clean build is the real correctness check — it confirms the fresh decomp + your
+splice line up with the new game API. Note `Mod.targets` deploys the built mod to your
+local Mods folder on success, so a green build also stages it for in-game testing.
+
+If it fails to compile, it's almost always because CO changed an API the system uses
+(a renamed field, a new method parameter). The fix is *not* to hand-port logic — the
+fresh decomp already contains the new vanilla code. Re-check that your splice didn't
+drop or mistype something, and that any field the hook references (`m_CurrentVehicleData`,
+`m_Passengers`, `m_SimulationFrameIndex`) still exists under that name in the new decomp.
+
+### 4. Bump version + changelog
+
+- `AllAboard/Settings/AllAboardSettings.cs` — bump `ModVersion`.
+- `README.md` — add a changelog entry at the top.
+- `AllAboard/Properties/PublishConfiguration.xml` — add the matching changelog entry.
+  Leave `ModId` untouched (it's the live Paradox Mods id).
+
+Ask the user for the changelog wording if it's not obvious from the diff — it's
+user-facing copy, not something to invent.
+
+### 5. Hand off
+
+Report the build result and the version bump. In-game behavior (does boarding actually
+cap at the slider value?) can only be confirmed by the user playing a save — say so
+rather than claiming the migration is "done/working" off a green build alone.
+
+## Notes
+
+- Keep edits to `Patched*.cs` surgical. They're decompiler output; the smaller your
+  footprint, the cleaner the diff against next version's fresh decomp.
+- The `EnableDiagnostics` path (`BoardingDiagnosticsSystem`) and the `Experimental/`
+  dead ends are unrelated to this migration — don't touch them.
+- If `ilspycmd` or the game install can't be found, the script fails loudly with the
+  fix; don't paper over it by guessing paths.
+- This is a "trust but verify" pipeline: the script handles the boring 99%, but the
+  splice and the build are where correctness is won. Don't skip the build.

--- a/.claude/skills/migrate-game-version/references/hook-splices.md
+++ b/.claude/skills/migrate-game-version/references/hook-splices.md
@@ -1,0 +1,177 @@
+# Hook splices
+
+This is the fragile, judgement-dependent half of a migration — the part a static script
+can't own, because CO reshapes this code on most updates. Find each hook by its *role*, not
+by matching last version's text, then apply the documented transform.
+
+There is exactly one hook per system, both inside the job's `StopBoarding` method.
+
+## The intent (why the hook exists)
+
+Vanilla ends boarding only when every assigned passenger has the `Ready` flag, OR when its
+own hardcoded dwell cap trips (`m_SimulationFrameIndex >= departureFrame + 1800`, ≈9.9 min).
+All Aboard! replaces that with a **configurable** cap via `PublicTransportBoardingHelper`,
+which reports "ready" once the boarding has run longer than the per-mode slider
+(`TrainMaxAllowedMinutesLate` / `BusMaxAllowedMinutesLate`) regardless of the `Ready` flags.
+
+**We deliberately excise vanilla's 1800-frame cap entirely** so the slider is the sole
+authority — otherwise vanilla's 9.9-min cap would override a user who set the slider higher.
+Excision means: delete the `num`/`flagN` cap locals, drop the `|| flagN` term from the
+`m_MaxBoardingDistance = math.select(...)` line, and remove the `if (!flagN)` guard around the
+ready-check. (`flagN` is whatever the decompiler named it — `flag2` in 1.5.9 car, `flag3` in
+1.5.9 train. Don't trust the number; trust the `+ 1800` shape.)
+
+## Finding the hook in a fresh decomp
+
+1. Jump to `private bool StopBoarding(...)` (the script prints its line number).
+2. Inside the `if (!forcedStop) { ... }` block, find the passenger-readiness check — the loop
+   (or method call) that inspects `CreatureVehicleFlags.Ready`. That is the hook site.
+3. Just above it sits vanilla's dwell-cap: a `uint num = math.max(...DepartureFrame...)` and a
+   `bool flagN = num != 0 && m_SimulationFrameIndex >= num + 1800;`, with `flagN` also folded
+   into the `math.select` for `m_MaxBoardingDistance` and gating the ready-check.
+
+If the surrounding code looks different from the examples below, that's expected — read what's
+actually there and preserve all of it except the cap and the ready-check.
+
+## Car — `PatchedTransportCarAISystem`
+
+The car ready-check is an inline `for` loop. Block-swap it; the car has no helper method.
+
+**Vanilla 1.5.9 (the part to change), inside `if (!forcedStop)`:**
+```csharp
+uint num = math.max(cargoTransport.m_DepartureFrame, publicTransport.m_DepartureFrame);
+bool flag2 = num != 0 && m_SimulationFrameIndex >= num + 1800;
+publicTransport.m_MaxBoardingDistance = math.select(publicTransport.m_MinWaitingDistance + 1f, float.MaxValue, publicTransport.m_MinWaitingDistance == float.MaxValue || publicTransport.m_MinWaitingDistance == 0f || flag2);
+publicTransport.m_MinWaitingDistance = float.MaxValue;
+if ((flag || ...) && (...))
+{
+    return false;
+}
+if (!flag2 && passengers.IsCreated)
+{
+    for (int i = 0; i < passengers.Length; i++)
+    {
+        Entity passenger = passengers[i].m_Passenger;
+        if (m_CurrentVehicleData.TryGetComponent(passenger, out var componentData3) && (componentData3.m_Flags & CreatureVehicleFlags.Ready) == 0)
+        {
+            return false;
+        }
+    }
+}
+```
+
+**After splice** (cap excised, helper call; leave the unchanged `if ((flag || ...))` block as-is):
+```csharp
+publicTransport.m_MaxBoardingDistance = math.select(publicTransport.m_MinWaitingDistance + 1f, float.MaxValue, publicTransport.m_MinWaitingDistance == float.MaxValue || publicTransport.m_MinWaitingDistance == 0f);
+publicTransport.m_MinWaitingDistance = float.MaxValue;
+if ((flag || ...) && (...))
+{
+    return false;
+}
+if (passengers.IsCreated)
+{
+    bool boardingComplete = PublicTransportBoardingHelper.ArePassengersReady(passengers, m_CurrentVehicleData, publicTransport, PublicTransportBoardingHelper.TransportFamily.Bus, m_SimulationFrameIndex);
+    if (!boardingComplete)
+    {
+        return false;
+    }
+}
+```
+
+Note `TransportFamily.Bus` (the car system covers buses) and `m_CurrentVehicleData` — the
+`ComponentLookup<CurrentVehicle>` field the vanilla loop already used. If CO renames that
+field, use the new name; the helper just needs the current-vehicle lookup.
+
+## Train — `PatchedTransportTrainAISystem`
+
+Trains are multi-car. In 1.5.9 vanilla already factors the per-vehicle check into a private
+`ArePassengersReady(Entity)` and iterates the `layout` in `StopBoarding`. The splice has two
+parts: (a) swap the inline layout loop for a call to our layout-aware overload, and (b) replace
+the vanilla per-vehicle method with that overload.
+
+### (a) In `StopBoarding`
+
+**Vanilla 1.5.9:**
+```csharp
+uint num = math.max(cargoTransport.m_DepartureFrame, publicTransport.m_DepartureFrame);
+bool flag3 = num != 0 && m_SimulationFrameIndex >= num + 1800;
+publicTransport.m_MaxBoardingDistance = math.select(... || flag3);
+publicTransport.m_MinWaitingDistance = float.MaxValue;
+if (flag2 && (...)) { return false; }
+if (!flag3)
+{
+    if (layout.Length != 0)
+    {
+        for (int i = 0; i < layout.Length; i++)
+        {
+            if (!ArePassengersReady(layout[i].m_Vehicle)) { return false; }
+        }
+    }
+    else if (!ArePassengersReady(vehicleEntity)) { return false; }
+}
+```
+(Here `flag2` is the unrelated "is this the boarding vehicle" flag — keep it. `flag3` is the
+dwell cap — excise it.)
+
+**After splice:**
+```csharp
+publicTransport.m_MaxBoardingDistance = math.select(publicTransport.m_MinWaitingDistance + 1f, float.MaxValue, publicTransport.m_MinWaitingDistance == float.MaxValue || publicTransport.m_MinWaitingDistance == 0f);
+publicTransport.m_MinWaitingDistance = float.MaxValue;
+if (flag2 && (...)) { return false; }
+bool boardingComplete = ArePassengersReady(vehicleEntity, ref layout, publicTransport);
+if (!boardingComplete)
+{
+    return false;
+}
+```
+
+### (b) Replace the private ready method
+
+Replace vanilla's `private bool ArePassengersReady(Entity vehicleEntity)` with this overload.
+It mirrors vanilla's layout iteration but defers each car's decision to the helper:
+```csharp
+private bool ArePassengersReady(Entity vehicleEntity, ref DynamicBuffer<LayoutElement> layout, PublicTransport publicTransport)
+{
+    bool boardingComplete = true;
+    if (layout.Length != 0)
+    {
+        for (int i = 0; i < layout.Length; i++)
+        {
+            Entity layoutVehicle = layout[i].m_Vehicle;
+            if (!m_Passengers.HasBuffer(layoutVehicle))
+            {
+                continue;
+            }
+            DynamicBuffer<Passenger> layoutVehiclePassengers = m_Passengers[layoutVehicle];
+            if (!PublicTransportBoardingHelper.ArePassengersReady(layoutVehiclePassengers, m_CurrentVehicleData, publicTransport, PublicTransportBoardingHelper.TransportFamily.Train, m_SimulationFrameIndex))
+            {
+                boardingComplete = false;
+                break;
+            }
+        }
+    }
+    else
+    {
+        boardingComplete = PublicTransportBoardingHelper.ArePassengersReady(m_Passengers[vehicleEntity], m_CurrentVehicleData, publicTransport, PublicTransportBoardingHelper.TransportFamily.Train, m_SimulationFrameIndex);
+    }
+    return boardingComplete;
+}
+```
+
+The field names this leans on (`m_Passengers`, `m_CurrentVehicleData`, `m_SimulationFrameIndex`,
+and the `layout` / `LayoutElement` types) are job-struct fields that have been stable. Verify
+each still exists in the new decomp before trusting the paste; if vanilla dropped its own
+single-arg `ArePassengersReady(Entity)`, then there's nothing to replace — just add this method
+and wire the call site in (a).
+
+## Verifying a splice (before the build)
+
+From the directory holding the spliced files:
+```
+grep -c "+ 1800" Patched*.cs          # expect 0,0 — the vanilla cap is gone
+grep -c "PublicTransportBoardingHelper.ArePassengersReady" Patched*.cs   # car 1, train 2
+```
+Then check no dwell-cap local is left dangling inside `StopBoarding` (other methods may have
+their own unrelated `flag2`/`flag3` — those are fine; only the `+ 1800` one is yours to remove).
+
+The real gate is the compile: `dotnet build`. See SKILL.md.

--- a/.claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1
+++ b/.claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1
@@ -43,11 +43,11 @@
 
 .EXAMPLE
     # Dry run: stage artifacts, change nothing tracked
-    pwsh ./Decompile-Systems.ps1
+    powershell -File ./Decompile-Systems.ps1
 
 .EXAMPLE
     # Real migration: write skeletons + diff references into the repo
-    pwsh ./Decompile-Systems.ps1 -Apply -WriteUnpatched
+    powershell -File ./Decompile-Systems.ps1 -Apply -WriteUnpatched
 #>
 [CmdletBinding()]
 param(
@@ -79,11 +79,13 @@ if ($Apply -and -not (Test-Path $patchedDir)) {
 
 # --- Resolve Game.dll --------------------------------------------------------
 if (-not $GameDll) {
-    $candidates = @(
-        (Join-Path $env:CSII_MANAGEDPATH 'Game.dll'),
-        (Join-Path $env:CSII_INSTALLATIONPATH 'Cities2_Data\Managed\Game.dll')
-    ) | Where-Object { $_ -and (Test-Path $_) }
-    $GameDll = $candidates | Select-Object -First 1
+    # Guard each var: $env:VAR is $null when unset, and Join-Path $null throws a
+    # terminating ParameterBindingValidationException under -ErrorActionPreference Stop,
+    # which would skip the friendly Fail below. The if () skips null/empty vars.
+    $candidates = @()
+    if ($env:CSII_MANAGEDPATH)      { $candidates += (Join-Path $env:CSII_MANAGEDPATH 'Game.dll') }
+    if ($env:CSII_INSTALLATIONPATH) { $candidates += (Join-Path $env:CSII_INSTALLATIONPATH 'Cities2_Data\Managed\Game.dll') }
+    $GameDll = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
 }
 if (-not $GameDll -or -not (Test-Path $GameDll)) {
     Fail "Could not locate Game.dll. Set CSII_MANAGEDPATH/CSII_INSTALLATIONPATH or pass -GameDll. Looked at: $GameDll"

--- a/.claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1
+++ b/.claude/skills/migrate-game-version/scripts/Decompile-Systems.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    Decompile the two transport AI systems from the installed Cities: Skylines II
+    Game.dll and produce All Aboard! "Patched" skeletons ready for the dwell-cap splice.
+
+.DESCRIPTION
+    This automates ONLY the parts of a game-version migration that are stable across
+    updates:
+      1. Locate Game.dll via the CSII_* environment variables.
+      2. Run ilspycmd (-lv CSharp7_3) to extract each transport system as a single type.
+      3. Rewrite the header so the decomp drops into the mod project:
+           - namespace Game.Simulation        -> namespace AllAboard.System.Patched
+           - class  TransportCarAISystem       -> class PatchedTransportCarAISystem
+             (word-boundary rename also catches the [Preserve] constructor)
+           - inject  using AllAboard.System.Utility;  (the helper's namespace)
+
+    It deliberately does NOT touch the StopBoarding hook. That splice is the fragile,
+    judgement-dependent part that changes shape every time CO refactors the system, so
+    it is left to the agent following SKILL.md + references/hook-splices.md.
+
+    Two artifacts are written per system into -OutDir:
+      Unpatched<Name>.cs  - verbatim decomp (namespace/class untouched). Diff anchor.
+      Patched<Name>.cs    - header-rewritten skeleton. Splice the hook into THIS file.
+
+.PARAMETER OutDir
+    Where to write the artifacts. Defaults to a staging folder under the system temp
+    dir so a bare run never disturbs tracked source.
+
+.PARAMETER Apply
+    Copy the results into the repo: Patched*.cs -> AllAboard/System/Patched/ and (when
+    -WriteUnpatched) Unpatched*.cs -> AllAboard/System/Experimental/. Without this switch
+    nothing in the repo changes.
+
+.PARAMETER WriteUnpatched
+    When applying, also drop the verbatim decomps into System/Experimental as diff
+    references (matches the "commit the decomp migration first" workflow in CLAUDE.md).
+
+.PARAMETER GameDll
+    Override the auto-detected Game.dll path.
+
+.PARAMETER RepoRoot
+    Override the auto-detected repo root (defaults to `git rev-parse --show-toplevel`).
+
+.EXAMPLE
+    # Dry run: stage artifacts, change nothing tracked
+    pwsh ./Decompile-Systems.ps1
+
+.EXAMPLE
+    # Real migration: write skeletons + diff references into the repo
+    pwsh ./Decompile-Systems.ps1 -Apply -WriteUnpatched
+#>
+[CmdletBinding()]
+param(
+    [string]$OutDir,
+    [switch]$Apply,
+    [switch]$WriteUnpatched,
+    [string]$GameDll,
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail($msg) { Write-Error $msg; exit 1 }
+
+# --- Resolve repo root -------------------------------------------------------
+if (-not $RepoRoot) {
+    try { $RepoRoot = (& git rev-parse --show-toplevel 2>$null) } catch {}
+}
+if (-not $RepoRoot -or -not (Test-Path $RepoRoot)) {
+    # Fall back to walking up from the script location (skill lives under .claude/).
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+}
+$RepoRoot = $RepoRoot.TrimEnd('\','/')
+$patchedDir      = Join-Path $RepoRoot 'AllAboard\System\Patched'
+$experimentalDir = Join-Path $RepoRoot 'AllAboard\System\Experimental'
+if ($Apply -and -not (Test-Path $patchedDir)) {
+    Fail "Expected $patchedDir to exist. Is -RepoRoot correct? ($RepoRoot)"
+}
+
+# --- Resolve Game.dll --------------------------------------------------------
+if (-not $GameDll) {
+    $candidates = @(
+        (Join-Path $env:CSII_MANAGEDPATH 'Game.dll'),
+        (Join-Path $env:CSII_INSTALLATIONPATH 'Cities2_Data\Managed\Game.dll')
+    ) | Where-Object { $_ -and (Test-Path $_) }
+    $GameDll = $candidates | Select-Object -First 1
+}
+if (-not $GameDll -or -not (Test-Path $GameDll)) {
+    Fail "Could not locate Game.dll. Set CSII_MANAGEDPATH/CSII_INSTALLATIONPATH or pass -GameDll. Looked at: $GameDll"
+}
+$managedDir = Split-Path $GameDll -Parent
+Write-Host "Game.dll : $GameDll"
+$gameInfo = Get-Item $GameDll
+Write-Host "  built  : $($gameInfo.LastWriteTime)  ($([math]::Round($gameInfo.Length/1MB,1)) MB)"
+
+# --- Resolve ilspycmd --------------------------------------------------------
+$ilspy = (Get-Command ilspycmd -ErrorAction SilentlyContinue).Source
+if (-not $ilspy) {
+    Fail "ilspycmd not found on PATH. Install it with:  dotnet tool install -g ilspycmd"
+}
+
+# --- Output dir --------------------------------------------------------------
+if (-not $OutDir) {
+    $OutDir = Join-Path $env:TEMP 'allaboard_migrate'
+}
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+Write-Host "OutDir   : $OutDir`n"
+
+# --- The two systems ---------------------------------------------------------
+$systems = @(
+    @{ Name = 'TransportCarAISystem';   Type = 'Game.Simulation.TransportCarAISystem'   },
+    @{ Name = 'TransportTrainAISystem'; Type = 'Game.Simulation.TransportTrainAISystem' }
+)
+
+$generated = @()
+foreach ($sys in $systems) {
+    $name = $sys.Name
+    $type = $sys.Type
+    Write-Host "=== $type ==="
+
+    # 1. Decompile. Run from the Managed dir so ilspycmd resolves sibling dependency DLLs.
+    Push-Location $managedDir
+    try {
+        & $ilspy (Split-Path $GameDll -Leaf) -t $type -lv CSharp7_3 --disable-updatecheck -o $OutDir | Out-Null
+    } finally {
+        Pop-Location
+    }
+    $raw = Join-Path $OutDir "$type.decompiled.cs"
+    if (-not (Test-Path $raw)) { Fail "ilspycmd produced no output for $type (expected $raw)" }
+
+    $text = Get-Content -Raw -LiteralPath $raw
+    Remove-Item -LiteralPath $raw -Force
+
+    # 2. Save the verbatim decomp as the Unpatched diff reference.
+    $unpatchedPath = Join-Path $OutDir "Unpatched$name.cs"
+    Set-Content -LiteralPath $unpatchedPath -Value $text -Encoding UTF8 -NoNewline
+
+    # 3. Header rewrite (the stable, mechanical transform).
+    $patched = $text
+    $patched = $patched -replace '(?m)^namespace Game\.Simulation\b', 'namespace AllAboard.System.Patched'
+    $patched = $patched -replace "\b$name\b", "Patched$name"          # class decl + [Preserve] ctor
+    # Inject the helper's namespace just before the namespace declaration.
+    $patched = $patched -replace '(?m)^namespace AllAboard\.System\.Patched',
+                                 "using AllAboard.System.Utility;`r`n`r`nnamespace AllAboard.System.Patched"
+    $header = @"
+// Auto-generated by the migrate-game-version skill from Game.dll (ILSpy, -lv CSharp7_3).
+// Source type: $type
+// This is a verbatim vanilla decompile; the All Aboard! dwell-cap hook must be spliced
+// into StopBoarding -- see .claude/skills/migrate-game-version/references/hook-splices.md.
+
+"@
+    $patched = $header + $patched
+
+    $patchedPath = Join-Path $OutDir "Patched$name.cs"
+    Set-Content -LiteralPath $patchedPath -Value $patched -Encoding UTF8 -NoNewline
+
+    # Locate StopBoarding to point the agent at the splice site.
+    $sbLine = (Select-String -LiteralPath $patchedPath -Pattern 'bool StopBoarding\(' | Select-Object -First 1).LineNumber
+    Write-Host "  -> Patched$name.cs   (StopBoarding near line $sbLine)"
+    Write-Host "  -> Unpatched$name.cs (diff reference)"
+
+    $generated += [pscustomobject]@{ Name = $name; Patched = $patchedPath; Unpatched = $unpatchedPath }
+    Write-Host ""
+}
+
+# --- Apply into the repo -----------------------------------------------------
+if ($Apply) {
+    foreach ($g in $generated) {
+        $dest = Join-Path $patchedDir "Patched$($g.Name).cs"
+        Copy-Item -LiteralPath $g.Patched -Destination $dest -Force
+        Write-Host "applied: $dest"
+        if ($WriteUnpatched) {
+            New-Item -ItemType Directory -Force -Path $experimentalDir | Out-Null
+            $udest = Join-Path $experimentalDir "Unpatched$($g.Name).cs"
+            Copy-Item -LiteralPath $g.Unpatched -Destination $udest -Force
+            Write-Host "applied: $udest"
+        }
+    }
+    Write-Host "`nNEXT: splice the StopBoarding hook into each Patched*.cs (see hook-splices.md), then build to verify."
+} else {
+    Write-Host "Dry run (no repo changes). Re-run with -Apply to write into the repo."
+    Write-Host "NEXT: review the staged files, splice the hook, then build to verify."
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# All Aboard! — agent notes
+
+Cities: Skylines II mod that puts a hard cap on transit dwell time. The README has the user-facing description; this file is the orientation an agent needs to work in the repo.
+
+## Layout
+
+```
+AllAboard.sln                       — solution at repo root
+AllAboard/                          — single C# project (net48)
+  AllAboard.cs                      — IMod entrypoint (OnLoad/OnDispose)
+  Settings/AllAboardSettings.cs     — sliders + locale
+  System/
+    Utility/
+      PublicTransportBoardingHelper.cs   — the actual mod logic (small)
+    Patched/
+      PatchedTransportCarAISystem.cs     — vanilla decomp + manual hooks (BUS path)
+      PatchedTransportTrainAISystem.cs   — vanilla decomp + manual hooks (TRAIN path)
+    Experimental/
+      Unpatched*AISystem.cs              — fresh vanilla decomps used for diffing on game updates
+      InstantBoardingSystem.cs           — abandoned alt approach, marked "DOES NOT WORK"
+  Properties/PublishConfiguration.xml    — Paradox Mods listing + changelog
+```
+
+## Build
+
+- `net48`, builds via the CSII modding toolchain. `AllAboard.csproj` imports `Mod.props`/`Mod.targets` from `%CSII_TOOLPATH%` (user env var). Game DLLs (`Game`, `Colossal.*`, `Unity.*`) come from there with `<Private>false</Private>` — never check binaries in.
+- Don't run `dotnet build` blindly without `CSII_TOOLPATH` set; the imports will fail silently into a useless build.
+- Publish profiles in `Properties/PublishProfiles/` upload to Paradox Mods (mod id `86605`).
+
+## How the mod works
+
+The mod is small in concept and large in code only because it ships full decompiles of two Burst-compiled systems.
+
+1. `OnLoad` disables the stock `TransportTrainAISystem` and `TransportCarAISystem`, then registers `PatchedTransportTrainAISystem`/`PatchedTransportCarAISystem` in the same `GameSimulation` phase.
+2. The two `Patched*` files are verbatim JetBrains decompiles of the stock systems with one hook spliced into each: where vanilla checks "are all assigned passengers `Ready`?", the patched code calls `PublicTransportBoardingHelper.ArePassengersReady(...)` instead.
+3. The helper's rule: passengers are considered "ready" once `simulationFrameIndex - publicTransport.m_DepartureFrame` exceeds `MaxAllowedMinutesLate` (in in-game minutes), regardless of actual `Ready` flags. This ends boarding and lets the `EndBoarding` path run normally — no teleporting, no flag flipping; the game's own `StopBoarding` cleans up stragglers.
+4. Settings are propagated into burst jobs via `SharedStatic<uint>` (`TrainMaxAllowedMinutesLate`, `BusMaxAllowedMinutesLate`). The static initializer in `PublicTransportBoardingHelper` is load-bearing — Burst `SharedStatic` is undefined behavior without one. Do not remove it.
+
+Conversion factor: `SimulationFramesPerMinute = 16384 / 90.0` (≈182.04). Source: cs2.paradoxwikis.com (linked in the helper).
+
+## Game-update workflow
+
+This repo's main maintenance task is "CO shipped a game patch, re-rebase the patched systems." The `migrate-game-version` skill (`.claude/skills/migrate-game-version/`) automates this end-to-end — invoke it when the game updates; the recipe below is the reference it follows and the manual fallback.
+
+1. Decompile the new `Game.dll` (JetBrains dotPeek). Pull the new `TransportCarAISystem` and `TransportTrainAISystem` into `System/Experimental/Unpatched*AISystem.cs`, replacing the previous unpatched copies. Commit that as a "decomp migration" so the rebase shows up cleanly in diff.
+2. Diff each `Unpatched*` against the corresponding `Patched*`. The mod's hooks are in exactly two spots per file — find the `if (!forcedStop) { ... }` block inside `StopBoarding` and replace its `ArePassengersReady` block with the helper call. Train hooks are around `PatchedTransportTrainAISystem.cs:1576-1602`; bus hooks are around `PatchedTransportCarAISystem.cs:1736-1742`.
+3. Carry over any new vanilla logic (CO frequently tweaks unrelated bits — refueling, dispatch, etc.). Keep the namespace `AllAboard.System.Patched`, partial class names, and the `using AllAboard.System.Utility;` import.
+4. Bump `ModVersion` in `AllAboardSettings.cs` and update the changelog at the top of `README.md` and `Properties/PublishConfiguration.xml`.
+
+## Current state vs vanilla 1.5.5
+
+The 1.5.5 stock systems (now in `System/Experimental/`) added their own dwell cap:
+
+```csharp
+uint num = math.max(cargoTransport.m_DepartureFrame, publicTransport.m_DepartureFrame);
+bool flag = num > 0U && m_SimulationFrameIndex >= num + 1800U;
+// when flag is true: skip the ArePassengersReady check and let StopBoarding finish
+```
+
+Same trigger as the mod (compare `m_SimulationFrameIndex` to `m_DepartureFrame`), same effect (skip the `Ready`-flag wait, let `EndBoarding` proceed). 1800 frames ≈ 9.89 in-game minutes — hardcoded, applied to both train and car AI identically. The mod's default is 8 minutes, configurable 0–30, with separate train/bus sliders. So vanilla is functionally the mod's approach, just slightly less aggressive and not user-tunable.
+
+This is worth keeping in mind: the README's "Future Work" goal of avoiding wholesale system replacement is now more achievable, since the only remaining value-add over vanilla is the configurable threshold. A drastically smaller mod could in principle just tweak `m_DepartureFrame` ahead of time, or Harmony-patch the threshold constant — but Burst compilation is why this codebase took the wholesale-replacement route in the first place, and that constraint hasn't changed.
+
+## Conventions / gotchas
+
+- `Patched/` files are decompiler output — large, ugly, and intentionally not refactored. Keep edits surgical so future diffs against fresh decomps stay readable.
+- `Experimental/` is reference material, not shipped code. The `InstantBoardingSystem` in there is a documented dead end (`DOES NOT WORK` in the file).
+- `Settings/AllAboardSettings.ApplyButton` writes directly into the `SharedStatic`s — this is the only way to push slider changes into a running burst job. Don't try to wire settings change events through `OnSettingsApplied` patterns; the existing button flow is intentional.
+- The mod ID and display name in `PublishConfiguration.xml` are the live ones on Paradox Mods. Don't change `ModId`.


### PR DESCRIPTION
Adds the migrate-game-version skill (.claude/skills/) that automates the "CO shipped a patch" decomp rebase: ilspycmd decompile + header rewrite via a helper script, judgement-guided StopBoarding hook splice, and build-verify.

Also removes the diagnostics docs from CLAUDE.md (BoardingDiagnosticsSystem / EnableDiagnostics live on a separate branch, not in this one) and points the Game-update workflow section at the new skill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and helper scripts only; no shipped mod or simulation logic changes.
> 
> **Overview**
> Introduces a **`migrate-game-version`** agent skill under `.claude/skills/` so CS2 game patches can be rebased without hand-decompiling every time.
> 
> The skill documents a split workflow: **`Decompile-Systems.ps1`** uses **ilspycmd** on the installed **`Game.dll`** to emit **`Patched*`** skeletons (namespace/class renames + `using AllAboard.System.Utility`) and optional **`Unpatched*`** diff anchors in **`System/Experimental`**, while **`references/hook-splices.md`** covers the manual **`StopBoarding`** dwell-cap splice into **`PublicTransportBoardingHelper`**, plus build-verify and version/changelog bumps.
> 
> Adds root **`CLAUDE.md`** as agent orientation (layout, build env, how patched systems work) and wires the **Game-update workflow** section to this skill instead of dotPeek-only steps; diagnostics / **`BoardingDiagnosticsSystem`** content is omitted here (lives on another branch per the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e82f46ae86f832d8bc8e997b9f8ece4a600ead09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->