### PR TITLE
docs: clarify mod's value vs vanilla's built-in dwell cap

### DIFF
--- a/AllAboard/Properties/PublishConfiguration.xml
+++ b/AllAboard/Properties/PublishConfiguration.xml
@@ -69,6 +69,11 @@ Eventually, all Cims _will_ be picked up, they just might have to wait for the n
 rest of us. This also helps trains/buses
 stay unbunched!
 
+**Note (game 1.5.5+):** Since the Iceflake update, Colossal Order ships their own fixed dwell cap of roughly 9.9
+in-game minutes (1800 frames), so vanilla no longer waits indefinitely for stuck boarders. What this mod adds on top
+is **control over that limit** — separate train/bus sliders from 0 to 30 minutes, defaulting to a tighter 8 minutes —
+so you can tune how aggressively your transit closes its doors instead of living with CO's single hardcoded value.
+
 ### Caveats:
 
 - This does not yet work with Taxis, as they use a separate AI system

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Eventually, all Cims _will_ be picked up, they just might have to wait for the n
 rest of us. This also helps trains/buses
 stay unbunched!
 
+**Note (game 1.5.5+):** Since the Iceflake update, Colossal Order ships their own fixed dwell cap of roughly 9.9
+in-game minutes (1800 frames), so vanilla no longer waits indefinitely for stuck boarders. What this mod adds on top
+is **control over that limit** — separate train/bus sliders from 0 to 30 minutes, defaulting to a tighter 8 minutes —
+so you can tune how aggressively your transit closes its doors instead of living with CO's single hardcoded value.
+
 ### Caveats:
 
 - This does not yet work with Taxis, as they use a separate AI system


### PR DESCRIPTION
## Summary
Clarifies the Technical Details in both `README.md` and `PublishConfiguration.xml`.

The section framed the mod as *introducing* the dwell cap, implying vanilla waits forever for stuck boarders. Since the **1.5.5 (Iceflake)** update, Colossal Order ships their own fixed ~9.9-minute (1800-frame) cap on both train and car AI — confirmed still present and unchanged in 1.6.0 — so vanilla already breaks the deadlock.

Adds a short note (end of Technical Details, before Caveats) explaining that the mod's value today is **configurability** — separate train/bus sliders, 0–30 min, default 8 — not introducing the cap. Kept flush-left in the publish config for Paradox's renderer.

This is documentation only; it matches what `CLAUDE.md`'s "Current state vs vanilla 1.5.5" already records internally.

## Note
I left out a more candid "if you're happy with vanilla's ~10-min cap you may not need this mod" line that I'd drafted — it's honest but counterproductive on a listing. Easy to add if you'd prefer the extra candor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to user-facing docs; no code, settings, or game behavior affected.
> 
> **Overview**
> Documentation-only update to **Technical Details** in `README.md` and `AllAboard/Properties/PublishConfiguration.xml`.
> 
> A new **Note (game 1.5.5+)** block is inserted after the boarding-behavior explanation and before **Caveats**. It states that since Iceflake, vanilla applies a fixed ~9.9-minute (1800-frame) dwell cap so stuck boarders no longer block transit forever. The mod’s differentiator is **configurability**: separate train and bus sliders from 0–30 minutes (default 8), so players can tune door-closing behavior instead of relying on Colossal Order’s single hardcoded cap.
> 
> No runtime or mod logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c73c93f26cf303cf9e24fda3579b712f5be6a168. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->